### PR TITLE
[feat] Add API endpoint to update category status to "Deleted"

### DIFF
--- a/SWD.F-LocalBrand.API/Controllers/CategoryController.cs
+++ b/SWD.F-LocalBrand.API/Controllers/CategoryController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using SWD.F_LocalBrand.API.Common;
+using SWD.F_LocalBrand.API.Payloads.Requests;
 using SWD.F_LocalBrand.API.Payloads.Requests.Category;
 using SWD.F_LocalBrand.API.Payloads.Responses;
 using SWD.F_LocalBrand.Business.Services;
@@ -175,6 +176,44 @@ namespace SWD.F_LocalBrand.API.Controllers
             }
         }
         #endregion
+        #region delete category api
+        [HttpDelete("delete-category")]
+        [SwaggerOperation(
+      Summary = "Delete a category",
+      Description = "Updates the status of a category to 'Deleted' and updates the status of related products to 'Inactive'."
+  )]
+        [SwaggerResponse(StatusCodes.Status200OK, "Category deleted successfully", typeof(ApiResult<object>))]
+        [SwaggerResponse(StatusCodes.Status404NotFound, "Category not found", typeof(ApiResult<object>))]
+        [SwaggerResponse(StatusCodes.Status500InternalServerError, "An error occurred while deleting the category", typeof(ApiResult<object>))]
+        public async Task<IActionResult> DeleteCategory([FromBody] CategoryDeleteRequest request)
+        {
+            if (!ModelState.IsValid)
+            {
+                var errors = ModelState.Values.SelectMany(v => v.Errors)
+                                               .Select(e => e.ErrorMessage)
+                                               .ToList();
+                return BadRequest(ApiResult<Dictionary<string, string[]>>.Error(new Dictionary<string, string[]>
+            {
+                { "Errors", errors.ToArray() }
+            }));
+            }
 
+            try
+            {
+                var deleteResult = await categoryService.DeleteCategoryAsync(request.Id);
+
+                if (!deleteResult)
+                {
+                    return NotFound(ApiResult<object>.Error(new { Message = "Category not found" }));
+                }
+
+                return Ok(ApiResult<object>.Succeed(new { Message = "Category deleted successfully" }));
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, ApiResult<object>.Fail(ex));
+            }
+        }
+        #endregion
     }
 }

--- a/SWD.F-LocalBrand.API/Payloads/Requests/CategoryDeleteRequest.cs
+++ b/SWD.F-LocalBrand.API/Payloads/Requests/CategoryDeleteRequest.cs
@@ -1,0 +1,10 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace SWD.F_LocalBrand.API.Payloads.Requests
+{
+    public class CategoryDeleteRequest
+    {
+        [Required(ErrorMessage = "Id is required.")]
+        public int Id { get; set; }
+    }
+}

--- a/SWD.F-LocalBrand.Data/Common/Interfaces/ICategoryRepository.cs
+++ b/SWD.F-LocalBrand.Data/Common/Interfaces/ICategoryRepository.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -9,5 +10,7 @@ namespace SWD.F_LocalBrand.Data.Common.Interfaces
 {
     public interface ICategoryRepository : IRepositoryBaseAsync<Category>
     {
+       
+       
     }
 }

--- a/SWD.F-LocalBrand.Data/Common/Interfaces/IRepositoryBaseAsync.cs
+++ b/SWD.F-LocalBrand.Data/Common/Interfaces/IRepositoryBaseAsync.cs
@@ -34,5 +34,6 @@ namespace SWD.F_LocalBrand.Data.Common.Interfaces
         Task<IDbContextTransaction> BeginTransactionAsync();
         Task EndTransactionAsync();
         Task RollbackTransactionAsync();
+       
     }
 }

--- a/SWD.F-LocalBrand.Data/Models/Category.cs
+++ b/SWD.F-LocalBrand.Data/Models/Category.cs
@@ -17,6 +17,8 @@ public partial class Category : EntityBase
 
     [Column("description")]
     public string? Description { get; set; }
+    [Column("status")]
+    public string? Status { get; set; }
 
     [InverseProperty("Category")]
     public virtual ICollection<Product> Products { get; set; } = new List<Product>();

--- a/SWD.F-LocalBrand.Data/Repositories/RepositoryBaseAsync.cs
+++ b/SWD.F-LocalBrand.Data/Repositories/RepositoryBaseAsync.cs
@@ -101,6 +101,7 @@ namespace SWD.F_LocalBrand.Data.Repositories
             _dbContext.Set<T>().RemoveRange(entities);
             return Task.CompletedTask;
         }
+
         
     }
 }

--- a/SWD.F-LocalBrand.Services/Common/Shared/CategoryStatusEnum.cs
+++ b/SWD.F-LocalBrand.Services/Common/Shared/CategoryStatusEnum.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SWD.F_LocalBrand.Business.Common.Shared
+{
+    public static class CategoryStatusEnum
+    {
+        public const string Active = "Active";
+        public const string Inactive = "Inactive";
+        public const string Deleted = "Deleted";
+    }
+}


### PR DESCRIPTION
- Implemented a new API endpoint PUT /api/categories/delete to update the status of a category to "Deleted".
- If the category is found and updated successfully, it changes the status to "Deleted".
- Checks if any associated products exist under the category; if so, updates their status to "Inactive".
- Handles validation and error scenarios appropriately.