### PR TITLE
[feat] Implement API endpoint to update category status

### DIFF
--- a/SWD.F-LocalBrand.API/Controllers/CategoryController.cs
+++ b/SWD.F-LocalBrand.API/Controllers/CategoryController.cs
@@ -215,5 +215,38 @@ namespace SWD.F_LocalBrand.API.Controllers
             }
         }
         #endregion
+        #region update status 
+        [HttpPut("update-status/{categoryId}")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> UpdateCategoryStatus(int categoryId, [FromBody] UpdateCategoryStatusRequest request)
+        {
+            if (!ModelState.IsValid)
+            {
+                var errors = ModelState.Values.SelectMany(v => v.Errors)
+                                               .Select(e => e.ErrorMessage)
+                                               .ToList();
+                return BadRequest(ApiResult<Dictionary<string, string[]>>.Error(new Dictionary<string, string[]>
+            {
+                { "Errors", errors.ToArray() }
+            }));
+            }
+            try
+            {
+                await categoryService.UpdateCategoryStatusAsync(categoryId, request.Status);
+                return Ok(ApiResult<object>.Succeed(new { Message = $"Category updated to {request.Status} successfully" }));
+            }
+            catch (ArgumentException ex)
+            {
+                return NotFound(ApiResult<object>.Error(new { Message = ex.Message }));
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, ApiResult<object>.Fail(ex));
+            }
+        }
+        #endregion 
     }
 }

--- a/SWD.F-LocalBrand.API/Payloads/Requests/Category/UpdateCategoryStatusRequest.cs
+++ b/SWD.F-LocalBrand.API/Payloads/Requests/Category/UpdateCategoryStatusRequest.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace SWD.F_LocalBrand.API.Payloads.Requests.Category
+{
+    public class UpdateCategoryStatusRequest
+    {
+        [Required(ErrorMessage = "Status is required.")]
+        [RegularExpression("^(Active|Inactive)$", ErrorMessage = "Status must be 'Active' or 'Inactive'.")]
+        public string Status { get; set; }
+    }
+}
+

--- a/SWD.F-LocalBrand.Services/Services/CategoryService.cs
+++ b/SWD.F-LocalBrand.Services/Services/CategoryService.cs
@@ -1,10 +1,12 @@
 ﻿using AutoMapper;
 using Microsoft.EntityFrameworkCore;
+using SWD.F_LocalBrand.Business.Common.Shared;
 using SWD.F_LocalBrand.Business.DTO;
 using SWD.F_LocalBrand.Business.DTO.Category;
 using SWD.F_LocalBrand.Data.Common.Interfaces;
 using SWD.F_LocalBrand.Data.Models;
 using SWD.F_LocalBrand.Data.Repositories;
+using SWD.F_LocalBrand.Data.UnitOfWorks;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -122,6 +124,31 @@ namespace SWD.F_LocalBrand.Business.Services
             return true;
         }
 
+        #endregion
+        #region update status category
+        public async Task UpdateCategoryStatusAsync(int categoryId, string status)
+        {
+            var category = await _unitOfWork.Categories.GetByIdAsync(categoryId);
+            if (category == null)
+            {
+                throw new ArgumentException("Category not found");
+            }
+
+            switch (status)
+            {
+                case CategoryStatusEnum.Active:
+                    category.Status = CategoryStatusEnum.Active;
+                    break;
+                case CategoryStatusEnum.Inactive:
+                    category.Status = CategoryStatusEnum.Inactive;
+                    break;
+                default:
+                    throw new ArgumentException("Invalid status. Status must be 'Active' or 'Inactive'");
+            }
+            await _unitOfWork.Categories.UpdateAsync(category);
+
+            await _unitOfWork.CommitAsync();
+        }
         #endregion
     }
 }


### PR DESCRIPTION
- Added PUT endpoint /api/categories/update-status/{categoryId} to CategoryController for updating category status.
- Implemented CategoryService.UpdateCategoryStatusAsync method to handle category status updates based on 'Active' or 'Inactive'.
- Introduced UpdateCategoryStatusRequest DTO to validate and deserialize status update requests.
- Enhanced error handling in controller to return appropriate responses for category not found and invalid status scenarios.